### PR TITLE
fix: add missing choices to asset_type in 0001_initial migration

### DIFF
--- a/src/wagtail_asset_publisher/migrations/0001_initial.py
+++ b/src/wagtail_asset_publisher/migrations/0001_initial.py
@@ -24,7 +24,13 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                ("asset_type", models.CharField(max_length=3)),
+                (
+                    "asset_type",
+                    models.CharField(
+                        choices=[("css", "CSS"), ("js", "JavaScript")],
+                        max_length=3,
+                    ),
+                ),
                 ("url", models.URLField(max_length=2048)),
                 ("content_hashes", models.JSONField(default=list)),
                 ("updated_at", models.DateTimeField(auto_now=True)),


### PR DESCRIPTION
## Summary

Add `choices=[("css", "CSS"), ("js", "JavaScript")]` to the `asset_type` CharField in `0001_initial.py`.

The model defines `choices=AssetType.choices` but the migration omitted it, causing Django's autodetector to generate spurious `AlterField` migrations inside site-packages.

## Changes

| File | Change |
|------|--------|
| `migrations/0001_initial.py` | Add `choices` param to `asset_type` field |

## Test plan

- [x] 286 existing tests pass
- [x] No new migrations generated by `makemigrations`

Closes #26