### PR TITLE
fix: set page site hostname on RequestFactory request (#31)

### DIFF
--- a/src/wagtail_asset_publisher/extractors.py
+++ b/src/wagtail_asset_publisher/extractors.py
@@ -237,7 +237,7 @@ def _get_page_hostname(page: object) -> str:
     try:
         site = page.get_site()  # type: ignore[attr-defined]
         if site is not None:
-            return site.hostname
+            return str(site.hostname)
     except Exception:
         pass
     return _DEFAULT_HOSTNAME

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -915,9 +915,7 @@ class TestGetPageHtmlForTailwind:
             mock.patch("wagtail.models.Page", FakePage),
             mock.patch("django.contrib.auth.models.AnonymousUser"),
             mock.patch("django.test.RequestFactory") as mock_rf,
-            mock.patch(
-                "wagtail_asset_publisher.extractors.logger"
-            ) as mock_logger,
+            mock.patch("wagtail_asset_publisher.extractors.logger") as mock_logger,
         ):
             mock_request = mock.Mock()
             mock_request.META = {
@@ -982,9 +980,7 @@ class TestGetPageHtmlForTailwind:
             ),
             mock.patch("django.contrib.auth.models.AnonymousUser"),
             mock.patch("django.test.RequestFactory") as mock_rf,
-            mock.patch(
-                "wagtail_asset_publisher.extractors.logger"
-            ) as mock_logger,
+            mock.patch("wagtail_asset_publisher.extractors.logger") as mock_logger,
         ):
             mock_request = mock.Mock()
             mock_request.META = {


### PR DESCRIPTION
## Summary

- Fix `DisallowedHost` error in `get_page_html_for_tailwind()` by setting `HTTP_HOST` and `SERVER_NAME` from `page.get_site().hostname` instead of relying on RequestFactory's default `"testserver"`
- Add `_get_page_hostname()` helper with fallback to `"localhost"` when site cannot be determined
- Wrap entire render in try/except with `logger.warning` for graceful degradation on any rendering failure

Closes #31

## Test plan

- [x] `TestGetPageHostname::test_returns_site_hostname` - hostname resolved from page site
- [x] `TestGetPageHostname::test_returns_fallback_when_get_site_returns_none` - fallback on None
- [x] `TestGetPageHostname::test_returns_fallback_when_get_site_raises` - fallback on exception
- [x] `TestGetPageHtmlForTailwind::test_sets_hostname_from_page_site` - HTTP_HOST/SERVER_NAME set correctly
- [x] `TestGetPageHtmlForTailwind::test_uses_fallback_hostname_when_site_unavailable` - fallback hostname used
- [x] `TestGetPageHtmlForTailwind::test_returns_empty_string_on_render_exception` - graceful degradation
- [x] `TestGetPageHtmlForTailwind::test_returns_empty_string_for_non_page_instance` - non-Page rejected
- [x] `TestGetPageHtmlForTailwind::test_render_to_string_exception_logs_page_info` - log contains pk/class
- [x] Full test suite: 294 passed