### PR TITLE
fix: decouple HTML minification from PublishedAsset dependency

### DIFF
--- a/src/wagtail_asset_publisher/middleware.py
+++ b/src/wagtail_asset_publisher/middleware.py
@@ -1,4 +1,4 @@
-"""Middleware for stripping inline assets and injecting static file references."""
+"""Middleware for HTML minification and optional asset injection for Wagtail pages."""
 
 from __future__ import annotations
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -932,6 +932,7 @@ class TestMiddlewarePreview:
         if isinstance(new_content, bytes):
             new_content = new_content.decode("utf-8")
         assert '<script src="https://cdn/tailwind.js"></script>' in new_content
+        mock_minify.assert_called_once()
 
     @mock.patch("wagtail_asset_publisher.middleware._minify_html")
     @mock.patch("wagtail_asset_publisher.preview.is_tailwind_builder")


### PR DESCRIPTION
## Summary
Closes #36

Decouple HTML minification from the PublishedAsset existence check so that all Wagtail page responses are minified regardless of whether they have extracted inline CSS/JS assets. Also apply minification to preview responses.

## Changes
| Target | Change | History |
|--------|--------|---------|
| `middleware.py` `__call__` | Move `_minify_html()` outside `if assets` block so it runs for all Wagtail pages | @Makoto Horikawa `a807f34` (2026-02-18) Initial commit: `if not assets: return response` early return. @kkm-horikawa `aad9484` (2026-02-19) PR #15 / Issue #11: `_minify_html` placed after assets check, making it unreachable for pages without assets |
| `middleware.py` `_handle_preview` | Restructure to always call `_minify_html()` on all exit paths | @Makoto Horikawa `a807f34` (2026-02-18) Initial commit: preview was Tailwind CDN injection only, multiple early returns bypassed minification |
| `middleware.py` docstrings | Update class and module docstrings to reflect new behavior | @Makoto Horikawa `a807f34` (2026-02-18) Initial commit: described middleware as "only activates for pages with published assets" |
| `tests/test_middleware.py` | Update existing tests + add 3 new unit tests (no-assets minify, Content-Length update, call order) | @kkm-horikawa `aad9484` (2026-02-19) PR #15: `test_no_published_assets_passes_through` expected unchanged pass-through |
| `tests/integration/test_html_minification.py` | New file: 9 integration tests for minification with/without assets, library unavailable, preview | New |
| `README.md` | Update "HTML Minification" behavior description | Described old behavior (only published page responses) |

## Test Plan
| Scenario | Action | Expected |
|----------|--------|----------|
| Page without assets, MINIFY_HTML=True | Access page | HTML is minified |
| Page without assets, MINIFY_HTML=False | Access page | HTML is NOT minified |
| Page with assets, MINIFY_HTML=True | Access page | Assets processed AND HTML minified |
| Page with assets, MINIFY_HTML=False | Access page | Assets processed, HTML NOT minified |
| Preview request (Tailwind builder) | Preview page | CDN injected AND HTML minified |
| Preview request (non-Tailwind) | Preview page | HTML is minified (no CDN) |
| Preview request, MINIFY_HTML=False | Preview page | CDN injected, HTML NOT minified |
| minify-html not installed | Access page | Graceful fallback, no error |
| minify-html not installed + assets | Access page | Assets still injected, no minification |
| Call order with assets | Access page with assets | `_process_html` before `_minify_html` |