### PR TITLE
Release v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ WAGTAIL_ASSET_PUBLISHER = {
     "TAILWIND_CLI_PATH": None,
     "TAILWIND_CONFIG": None,
     "TAILWIND_BASE_CSS": None,
+    "TAILWIND_PLUGINS": [],
     "TAILWIND_CDN_URL": "https://unpkg.com/@tailwindcss/browser@4",
     # Asset optimization (requires pip install wagtail-asset-publisher[minify])
     "MINIFY_CSS": True,
@@ -145,6 +146,7 @@ WAGTAIL_ASSET_PUBLISHER = {
 | `TAILWIND_CLI_PATH` | `None` | Path to Tailwind CLI binary (auto-detected if not set) |
 | `TAILWIND_CONFIG` | `None` | Path to Tailwind config file |
 | `TAILWIND_BASE_CSS` | `None` | Path to base input CSS file for Tailwind |
+| `TAILWIND_PLUGINS` | `[]` | List of Tailwind CSS v4 first-party plugin package names to activate via `@plugin` directives. Ignored when `TAILWIND_BASE_CSS` is set. See [Using Tailwind CSS Plugins](#using-tailwind-css-plugins). |
 | `TAILWIND_CDN_URL` | `"https://unpkg.com/@tailwindcss/browser@4"` | Tailwind CDN URL for preview mode |
 | `MINIFY_CSS` | `True` | Minify CSS output via rcssmin (requires `minify` extra) |
 | `OBFUSCATE_JS` | `False` | Minify/obfuscate JS output via terser or rjsmin (requires `minify` extra) |
@@ -357,6 +359,43 @@ WAGTAIL_ASSET_PUBLISHER = {
 6. If the CLI fails, the builder gracefully falls back to raw CSS output
 
 **Preview support:** When using the Tailwind builder, the middleware automatically injects the Tailwind CSS browser CDN script into preview responses. This lets editors see Tailwind utility classes rendered in real time before publishing. The CDN script is never injected in published pages.
+
+### Using Tailwind CSS Plugins
+
+Tailwind CSS v4 ships with several first-party plugins that can be activated via `@plugin` directives. Instead of manually managing a base CSS file, you can list the plugins in the `TAILWIND_PLUGINS` setting and they will be injected automatically:
+
+```python
+WAGTAIL_ASSET_PUBLISHER = {
+    "CSS_BUILDER": "wagtail_asset_publisher.builders.tailwind.TailwindCSSBuilder",
+    "TAILWIND_PLUGINS": [
+        "@tailwindcss/typography",
+        "@tailwindcss/forms",
+    ],
+}
+```
+
+This generates the following input CSS for the Tailwind CLI:
+
+```css
+@import "tailwindcss";
+@plugin "@tailwindcss/typography";
+@plugin "@tailwindcss/forms";
+@source "/tmp/.../content.html";
+```
+
+**Available first-party plugins (bundled with the standalone CLI):**
+
+- `@tailwindcss/typography` -- Beautiful typographic defaults for HTML content
+- `@tailwindcss/forms` -- Form element reset and styling utilities
+- `@tailwindcss/aspect-ratio` -- Aspect ratio utilities for legacy browser support
+
+> **Note:** The `@tailwindcss/container-queries` plugin is built into Tailwind CSS v4 core. No plugin activation is needed -- `@container` queries and `@min-*`/`@max-*` variants work out of the box.
+
+> **Note:** Third-party plugins (not bundled with Tailwind) require a Node.js-based Tailwind CLI installation. The standalone binary only supports first-party plugins. If you need third-party plugins, use `TAILWIND_BASE_CSS` to provide a fully custom input CSS file.
+
+When `TAILWIND_BASE_CSS` is set, `TAILWIND_PLUGINS` is ignored entirely because the user controls the full input CSS. For advanced customization beyond plugin activation, see the `TAILWIND_BASE_CSS` setting.
+
+> **Note:** Plugin styles are not available in Wagtail's preview mode. The Tailwind CSS browser CDN (`@tailwindcss/browser@4`) used for previews does not include plugin implementations. Published pages will render plugin styles correctly since they are compiled by the standalone CLI.
 
 ### Cross-Package Integration
 

--- a/src/wagtail_asset_publisher/builders/tailwind.py
+++ b/src/wagtail_asset_publisher/builders/tailwind.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 TAILWIND_CLI_TIMEOUT_SECONDS = 30
 DEFAULT_TAILWIND_INPUT = '@import "tailwindcss";\n'
+SAFE_PLUGIN_NAME_RE = re.compile(r"^@?[\w./-]+$")
 
 
 class TailwindCSSBuilder(BaseAssetBuilder):
@@ -72,6 +74,33 @@ class TailwindCSSBuilder(BaseAssetBuilder):
 
         return "tailwindcss"
 
+    def _validate_plugins(self, raw_value: object) -> list[str]:
+        """Validate TAILWIND_PLUGINS and return only safe plugin names.
+
+        Returns an empty list when the value is not a list or is None.
+        Individual entries that fail the safe-name check are skipped.
+        """
+        if raw_value is None:
+            return []
+
+        if not isinstance(raw_value, list):
+            logger.warning(
+                "TAILWIND_PLUGINS must be a list, got %s. Plugin injection skipped.",
+                type(raw_value).__name__,
+            )
+            return []
+
+        valid: list[str] = []
+        for entry in raw_value:
+            if not isinstance(entry, str) or not SAFE_PLUGIN_NAME_RE.match(entry):
+                logger.warning(
+                    "Invalid plugin name skipped: %r",
+                    entry,
+                )
+                continue
+            valid.append(entry)
+        return valid
+
     def _build_input_css(
         self, custom_css: str, content_file: Path | None = None
     ) -> str:
@@ -80,12 +109,20 @@ class TailwindCSSBuilder(BaseAssetBuilder):
         When *content_file* is provided, a Tailwind v4 ``@source`` directive
         is inserted so the JIT compiler scans only that file for utility
         classes.
+
+        When ``TAILWIND_BASE_CSS`` is **not** set, ``@plugin`` directives from
+        the ``TAILWIND_PLUGINS`` setting are injected between the
+        ``@import "tailwindcss"`` statement and the ``@source`` directive.
         """
         base_css_path: str | None = get_setting("TAILWIND_BASE_CSS")
         if base_css_path:
             input_css = Path(base_css_path).read_text(encoding="utf-8")
         else:
             input_css = DEFAULT_TAILWIND_INPUT
+
+            plugins = self._validate_plugins(get_setting("TAILWIND_PLUGINS"))
+            for plugin in plugins:
+                input_css += f'@plugin "{plugin}";\n'
 
         if content_file is not None:
             input_css += f'@source "{content_file}";\n'

--- a/src/wagtail_asset_publisher/conf.py
+++ b/src/wagtail_asset_publisher/conf.py
@@ -17,6 +17,7 @@ DEFAULTS: dict[str, Any] = {
     "TAILWIND_CLI_PATH": None,
     "TAILWIND_CONFIG": None,
     "TAILWIND_BASE_CSS": None,
+    "TAILWIND_PLUGINS": [],
     # Asset optimization
     "OBFUSCATE_JS": False,
     "MINIFY_CSS": True,

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -35,6 +35,7 @@ import pytest
 from wagtail_asset_publisher.builders.raw import RawAssetBuilder
 from wagtail_asset_publisher.builders.tailwind import (
     DEFAULT_TAILWIND_INPUT,
+    SAFE_PLUGIN_NAME_RE,
     TailwindCSSBuilder,
 )
 
@@ -565,6 +566,547 @@ class TestTailwindBuildInputCss:
         source_pos = result.index('@source "/tmp/content.html"')
         custom_pos = result.index(".custom { color: red; }")
         assert base_pos < source_pos < custom_pos
+
+    def test_no_plugins_injected_when_not_configured(self):
+        """No @plugin directives when TAILWIND_PLUGINS is empty (default).
+
+        Purpose: Verify that _build_input_css() does not inject any @plugin
+                 directives when TAILWIND_PLUGINS is an empty list.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Equivalence partitioning
+        Test data: TAILWIND_PLUGINS=[], TAILWIND_BASE_CSS=None
+        """
+        builder = TailwindCSSBuilder()
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": [],
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert "@plugin" not in result
+
+    def test_single_plugin_injected(self):
+        """Single @plugin directive injected for one configured plugin.
+
+        Purpose: Verify that _build_input_css() injects a single @plugin
+                 directive when TAILWIND_PLUGINS contains one entry.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Equivalence partitioning
+        Test data: TAILWIND_PLUGINS=["@tailwindcss/typography"]
+        """
+        builder = TailwindCSSBuilder()
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": ["@tailwindcss/typography"],
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert '@plugin "@tailwindcss/typography";' in result
+
+    def test_multiple_plugins_injected_in_order(self):
+        """Multiple @plugin directives injected in configured order.
+
+        Purpose: Verify that _build_input_css() injects @plugin directives
+                 for all entries in TAILWIND_PLUGINS, preserving order.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Equivalence partitioning
+        Test data: TAILWIND_PLUGINS with typography and forms
+        """
+        builder = TailwindCSSBuilder()
+        plugins = ["@tailwindcss/typography", "@tailwindcss/forms"]
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": plugins,
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        typography_pos = result.index('@plugin "@tailwindcss/typography"')
+        forms_pos = result.index('@plugin "@tailwindcss/forms"')
+        assert typography_pos < forms_pos
+
+    def test_plugins_ignored_when_base_css_set(self):
+        """TAILWIND_PLUGINS is ignored when TAILWIND_BASE_CSS is set.
+
+        Purpose: Verify that _build_input_css() does not inject @plugin
+                 directives when the user provides a custom base CSS file,
+                 since they have full control over the input CSS.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Decision coverage (C1)
+        Test data: TAILWIND_BASE_CSS set, TAILWIND_PLUGINS non-empty
+        """
+        builder = TailwindCSSBuilder()
+        base_css_content = '@import "tailwindcss";\n@layer components {}'
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": "/path/to/base.css",
+                "TAILWIND_PLUGINS": ["@tailwindcss/typography"],
+            }
+            return settings.get(key)
+
+        with (
+            mock.patch(
+                "wagtail_asset_publisher.builders.tailwind.get_setting",
+                side_effect=mock_get_setting,
+            ),
+            mock.patch.object(
+                Path,
+                "read_text",
+                return_value=base_css_content,
+            ),
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert "@plugin" not in result
+
+    def test_plugin_directive_ordering(self):
+        """Ordering: @import < @plugin directives < @source < custom CSS.
+
+        Purpose: Verify that _build_input_css() produces output in the correct
+                 order: @import first, @plugin directives second, @source
+                 third, custom CSS last.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Statement coverage (C0)
+        Test data: Plugin + content_file + custom CSS
+        """
+        builder = TailwindCSSBuilder()
+        content_file = Path("/tmp/content.html")
+        custom_css = ".custom { color: red; }"
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": ["@tailwindcss/typography"],
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css(custom_css, content_file=content_file)
+
+        import_pos = result.index('@import "tailwindcss"')
+        plugin_pos = result.index('@plugin "@tailwindcss/typography"')
+        source_pos = result.index('@source "/tmp/content.html"')
+        custom_pos = result.index(".custom { color: red; }")
+        assert import_pos < plugin_pos < source_pos < custom_pos
+
+    def test_plugin_directives_have_semicolons(self):
+        """Each @plugin directive ends with a semicolon.
+
+        Purpose: Verify that every @plugin line has a trailing semicolon,
+                 since missing semicolons cause cryptic Tailwind parser errors.
+        Category: Normal case
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Error guessing (missing semicolons)
+        Test data: Multiple plugins
+        """
+        builder = TailwindCSSBuilder()
+        plugins = ["@tailwindcss/typography", "@tailwindcss/forms"]
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": plugins,
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        plugin_lines = [
+            line for line in result.splitlines() if line.startswith("@plugin")
+        ]
+        assert len(plugin_lines) == len(plugins)
+        for line in plugin_lines:
+            assert line.endswith(";")
+
+
+class TestValidatePlugins:
+    """Tests for TailwindCSSBuilder._validate_plugins().
+
+    Validates that TAILWIND_PLUGINS setting values are safe before
+    injecting them into generated CSS.
+    """
+
+    def test_none_returns_empty_list(self):
+        """None value returns empty list without warning.
+
+        Purpose: Verify that _validate_plugins(None) returns an empty list
+                 (the common case when the setting is not configured).
+        Category: Normal case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Boundary value analysis (None input)
+        Test data: None
+        """
+        builder = TailwindCSSBuilder()
+
+        result = builder._validate_plugins(None)
+
+        assert result == []
+
+    def test_valid_list_passes_through(self):
+        """A list of valid plugin names is returned as-is.
+
+        Purpose: Verify that _validate_plugins() passes through a valid list
+                 of plugin names without modification.
+        Category: Normal case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Equivalence partitioning
+        Test data: List with two valid scoped package names
+        """
+        builder = TailwindCSSBuilder()
+        plugins = ["@tailwindcss/typography", "@tailwindcss/forms"]
+
+        result = builder._validate_plugins(plugins)
+
+        assert result == plugins
+
+    def test_string_value_returns_empty_and_warns(self, caplog):
+        """A string value (common misconfiguration) is rejected with warning.
+
+        Purpose: Verify that _validate_plugins() returns an empty list and
+                 logs a warning when the value is a string instead of a list.
+                 This prevents iterating over characters of the string.
+        Category: Error case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (common misconfiguration)
+        Test data: "tailwindcss/typography" (string instead of list)
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins("tailwindcss/typography")
+
+        assert result == []
+        assert "TAILWIND_PLUGINS must be a list" in caplog.text
+        assert "str" in caplog.text
+
+    def test_tuple_value_returns_empty_and_warns(self, caplog):
+        """A tuple value is rejected with warning.
+
+        Purpose: Verify that _validate_plugins() rejects non-list iterables
+                 (tuple) to enforce strict type checking.
+        Category: Error case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (wrong iterable type)
+        Test data: Tuple of plugin names
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(("@tailwindcss/typography",))
+
+        assert result == []
+        assert "TAILWIND_PLUGINS must be a list" in caplog.text
+        assert "tuple" in caplog.text
+
+    def test_integer_value_returns_empty_and_warns(self, caplog):
+        """An integer value is rejected with warning.
+
+        Purpose: Verify that _validate_plugins() rejects non-iterable types.
+        Category: Error case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (wrong type)
+        Test data: Integer 42
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(42)
+
+        assert result == []
+        assert "TAILWIND_PLUGINS must be a list" in caplog.text
+
+    def test_plugin_name_with_double_quote_skipped(self, caplog):
+        """Plugin name containing a double-quote is skipped with warning.
+
+        Purpose: Verify that a plugin name with an embedded double-quote
+                 is rejected, preventing CSS injection via @plugin "bad"name";
+        Category: Security case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (CSS injection via quote)
+        Test data: ['bad"name']
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(['bad"name'])
+
+        assert result == []
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_plugin_name_with_semicolon_skipped(self, caplog):
+        """Plugin name containing a semicolon is skipped with warning.
+
+        Purpose: Verify that a plugin name with a semicolon is rejected,
+                 preventing premature CSS statement termination.
+        Category: Security case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (CSS injection via semicolon)
+        Test data: ['bad;name']
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(["bad;name"])
+
+        assert result == []
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_plugin_name_with_space_skipped(self, caplog):
+        """Plugin name containing a space is skipped with warning.
+
+        Purpose: Verify that a plugin name with spaces is rejected.
+        Category: Error case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (whitespace in name)
+        Test data: ['bad name']
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(["bad name"])
+
+        assert result == []
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_non_string_entry_skipped(self, caplog):
+        """Non-string entries in the list are skipped with warning.
+
+        Purpose: Verify that non-string items (e.g. integers) within
+                 the plugin list are skipped individually.
+        Category: Error case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Error guessing (mixed types in list)
+        Test data: [123, "@tailwindcss/typography"]
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins([123, "@tailwindcss/typography"])
+
+        assert result == ["@tailwindcss/typography"]
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_mixed_valid_and_invalid_entries(self, caplog):
+        """Valid entries pass through while invalid ones are skipped.
+
+        Purpose: Verify that _validate_plugins() filters out only the
+                 invalid entries while keeping valid ones in order.
+        Category: Normal case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Equivalence partitioning (mixed input)
+        Test data: Mix of valid and invalid plugin names
+        """
+        builder = TailwindCSSBuilder()
+        plugins = [
+            "@tailwindcss/typography",
+            'bad"quote',
+            "@tailwindcss/forms",
+        ]
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins(plugins)
+
+        assert result == ["@tailwindcss/typography", "@tailwindcss/forms"]
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_empty_string_entry_skipped(self, caplog):
+        """Empty string plugin name is skipped with warning.
+
+        Purpose: Verify that an empty string entry is rejected because
+                 it does not match the safe plugin name pattern.
+        Category: Edge case
+        Target: TailwindCSSBuilder._validate_plugins(raw_value)
+        Technique: Boundary value analysis (empty string)
+        Test data: [""]
+        """
+        builder = TailwindCSSBuilder()
+
+        with caplog.at_level("WARNING"):
+            result = builder._validate_plugins([""])
+
+        assert result == []
+        assert "Invalid plugin name skipped" in caplog.text
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "@tailwindcss/typography",
+            "@tailwindcss/forms",
+            "tailwindcss-animate",
+            "daisyui",
+            "@myorg/my-plugin",
+            "plugin_with_underscore",
+            "plugin.with.dots",
+        ],
+    )
+    def test_safe_plugin_name_pattern_accepts_valid_names(self, name):
+        """SAFE_PLUGIN_NAME_RE accepts typical Tailwind plugin names.
+
+        Purpose: Verify that the regex pattern matches common valid
+                 plugin name formats (scoped packages, hyphens, dots, etc.).
+        Category: Normal case
+        Target: SAFE_PLUGIN_NAME_RE
+        Technique: Equivalence partitioning (valid inputs)
+        Test data: Various valid plugin name formats
+        """
+        assert SAFE_PLUGIN_NAME_RE.match(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            'bad"quote',
+            "bad;semicolon",
+            "bad name",
+            "bad\nline",
+            "",
+            "bad{brace",
+            "bad}brace",
+        ],
+    )
+    def test_safe_plugin_name_pattern_rejects_invalid_names(self, name):
+        """SAFE_PLUGIN_NAME_RE rejects names with unsafe characters.
+
+        Purpose: Verify that the regex pattern rejects plugin names
+                 containing characters that could cause CSS parse errors.
+        Category: Security case
+        Target: SAFE_PLUGIN_NAME_RE
+        Technique: Error guessing (unsafe characters)
+        Test data: Various invalid plugin name formats
+        """
+        assert not SAFE_PLUGIN_NAME_RE.match(name)
+
+
+class TestBuildInputCssPluginValidation:
+    """Integration tests: _build_input_css with invalid TAILWIND_PLUGINS values."""
+
+    def test_string_plugins_produces_no_directives(self, caplog):
+        """String TAILWIND_PLUGINS produces no @plugin directives.
+
+        Purpose: Verify that _build_input_css() does not produce broken
+                 per-character @plugin directives when TAILWIND_PLUGINS is
+                 a string instead of a list.
+        Category: Error case (integration)
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Error guessing (common misconfiguration)
+        Test data: TAILWIND_PLUGINS="tailwindcss/typography" (string)
+        """
+        builder = TailwindCSSBuilder()
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": "tailwindcss/typography",
+            }
+            return settings.get(key)
+
+        with (
+            caplog.at_level("WARNING"),
+            mock.patch(
+                "wagtail_asset_publisher.builders.tailwind.get_setting",
+                side_effect=mock_get_setting,
+            ),
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert "@plugin" not in result
+        assert result == DEFAULT_TAILWIND_INPUT
+        assert "TAILWIND_PLUGINS must be a list" in caplog.text
+
+    def test_plugin_with_quote_skipped_in_output(self, caplog):
+        """Plugin name with double-quote is excluded from generated CSS.
+
+        Purpose: Verify that _build_input_css() does not produce a broken
+                 @plugin directive when a plugin name contains a double-quote.
+        Category: Security case (integration)
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Error guessing (CSS injection)
+        Test data: TAILWIND_PLUGINS=['bad"name', '@tailwindcss/forms']
+        """
+        builder = TailwindCSSBuilder()
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": ['bad"name', "@tailwindcss/forms"],
+            }
+            return settings.get(key)
+
+        with (
+            caplog.at_level("WARNING"),
+            mock.patch(
+                "wagtail_asset_publisher.builders.tailwind.get_setting",
+                side_effect=mock_get_setting,
+            ),
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert '@plugin "@tailwindcss/forms";' in result
+        assert "bad" not in result
+        assert "Invalid plugin name skipped" in caplog.text
+
+    def test_none_plugins_produces_no_directives(self):
+        """None TAILWIND_PLUGINS produces no @plugin directives.
+
+        Purpose: Verify that _build_input_css() gracefully handles
+                 TAILWIND_PLUGINS=None (the default when not configured).
+        Category: Normal case (integration)
+        Target: TailwindCSSBuilder._build_input_css(custom_css, content_file)
+        Technique: Boundary value analysis (None)
+        Test data: TAILWIND_PLUGINS=None
+        """
+        builder = TailwindCSSBuilder()
+
+        def mock_get_setting(key):
+            settings = {
+                "TAILWIND_BASE_CSS": None,
+                "TAILWIND_PLUGINS": None,
+            }
+            return settings.get(key)
+
+        with mock.patch(
+            "wagtail_asset_publisher.builders.tailwind.get_setting",
+            side_effect=mock_get_setting,
+        ):
+            result = builder._build_input_css("", content_file=None)
+
+        assert "@plugin" not in result
+        assert result == DEFAULT_TAILWIND_INPUT
 
 
 class TestTailwindBuildCommand:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -168,6 +168,18 @@ class TestDefaultValues:
         """
         assert DEFAULTS["HASH_LENGTH"] == 8
 
+    def test_tailwind_plugins_default_is_empty_list(self):
+        """TAILWIND_PLUGINS defaults to an empty list.
+
+        Purpose: Verify that TAILWIND_PLUGINS defaults to [], ensuring no
+            plugin directives are injected unless explicitly configured.
+        Category: Normal case
+        Target: DEFAULTS["TAILWIND_PLUGINS"]
+        Technique: Equivalence partitioning
+        Test data: DEFAULTS dict value
+        """
+        assert DEFAULTS["TAILWIND_PLUGINS"] == []
+
     def test_defaults_contains_v2_required_keys(self):
         """DEFAULTS contains all keys required by v2 architecture.
 
@@ -189,6 +201,7 @@ class TestDefaultValues:
             "TAILWIND_CLI_PATH",
             "TAILWIND_CONFIG",
             "TAILWIND_BASE_CSS",
+            "TAILWIND_PLUGINS",
             "MINIFY_HTML",
             "OBFUSCATE_JS",
             "MINIFY_CSS",


### PR DESCRIPTION
## Summary

Release v0.3.1 — adds `TAILWIND_PLUGINS` setting for first-party Tailwind CSS plugin activation.

### 🚀 Features

- **TAILWIND_PLUGINS setting** (#44, #45): New list setting to activate Tailwind CSS v4 first-party plugins (`@tailwindcss/typography`, `@tailwindcss/forms`, `@tailwindcss/aspect-ratio`) without overriding the entire base CSS via `TAILWIND_BASE_CSS`. Includes input validation with safe plugin name regex and graceful degradation on misconfiguration.

### 📚 Documentation

- Added "Using Tailwind CSS Plugins" section to README with configuration examples, bundled plugin list, and preview mode limitation note.