### PR TITLE
fix: strip domain from storage URLs for multi-site compatibility

### DIFF
--- a/src/wagtail_asset_publisher/storage/django_storage.py
+++ b/src/wagtail_asset_publisher/storage/django_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 
@@ -18,7 +20,9 @@ class DjangoStorageBackend(BaseAssetStorage):
             default_storage.delete(path)
 
         saved_path = default_storage.save(path, ContentFile(content.encode("utf-8")))
-        return default_storage.url(saved_path)
+        url = default_storage.url(saved_path)
+        parsed = urlparse(url)
+        return parsed.path if parsed.scheme else url
 
     def delete(self, path: str) -> None:
         if default_storage.exists(path):

--- a/src/wagtail_asset_publisher/storage/local.py
+++ b/src/wagtail_asset_publisher/storage/local.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 from django.conf import settings
 
@@ -28,7 +29,9 @@ class LocalFileStorage(BaseAssetStorage):
 
     def _get_url(self, path: str) -> str:
         static_url: str = getattr(settings, "STATIC_URL", "/static/")
-        return f"{static_url.rstrip('/')}/{path}"
+        url = f"{static_url.rstrip('/')}/{path}"
+        parsed = urlparse(url)
+        return parsed.path if parsed.scheme else url
 
     def save(self, path: str, content: str) -> str:
         full_path = self._get_full_path(path)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -36,6 +36,61 @@ class TestDjangoStorageBackendSave:
         mock_storage.save.assert_called_once()
         mock_storage.delete.assert_not_called()
 
+    def test_save_strips_domain_from_absolute_url(self):
+        """Strip domain from absolute URL returned by default_storage.url().
+
+        Purpose: Verify that DjangoStorageBackend.save() converts an absolute
+            URL (with scheme and domain) to a relative path, ensuring correct
+            behavior on multi-site / CDN deployments where default_storage.url()
+            returns a full URL like https://cdn.example.com/media/....
+        Category: Normal case
+        Target: DjangoStorageBackend.save(path, content)
+        Technique: Equivalence partitioning
+        Test data: default_storage.url() returning an absolute URL with
+            https scheme and CDN domain
+        """
+        backend = DjangoStorageBackend()
+        path = "page-assets/css/42-abcd1234.css"
+        content = "body { color: red; }"
+
+        with mock.patch(
+            "wagtail_asset_publisher.storage.django_storage.default_storage"
+        ) as mock_storage:
+            mock_storage.exists.return_value = False
+            mock_storage.save.return_value = path
+            mock_storage.url.return_value = f"https://cdn.example.com/media/{path}"
+
+            result = backend.save(path, content)
+
+        assert result == f"/media/{path}"
+
+    def test_save_preserves_relative_url(self):
+        """Preserve relative URL returned by default_storage.url().
+
+        Purpose: Verify that DjangoStorageBackend.save() returns a relative
+            URL unchanged when default_storage.url() already returns a
+            path-only URL, ensuring no unintended transformation on standard
+            local storage setups.
+        Category: Normal case
+        Target: DjangoStorageBackend.save(path, content)
+        Technique: Equivalence partitioning
+        Test data: default_storage.url() returning a relative path-only URL
+        """
+        backend = DjangoStorageBackend()
+        path = "page-assets/css/42-abcd1234.css"
+        content = "body { color: red; }"
+
+        with mock.patch(
+            "wagtail_asset_publisher.storage.django_storage.default_storage"
+        ) as mock_storage:
+            mock_storage.exists.return_value = False
+            mock_storage.save.return_value = path
+            mock_storage.url.return_value = f"/media/{path}"
+
+            result = backend.save(path, content)
+
+        assert result == f"/media/{path}"
+
     def test_save_overwrites_existing_file(self):
         """Delete existing file before saving.
 
@@ -357,6 +412,51 @@ class TestLocalFileStorageStaticRootValidation:
             "wagtail_asset_publisher.storage.local.settings"
         ) as mock_settings:
             mock_settings.STATIC_URL = "/static"
+
+            result = backend._get_url("page-assets/css/42.css")
+
+        assert result == "/static/page-assets/css/42.css"
+
+    def test_get_url_strips_domain_from_absolute_static_url(self):
+        """Strip domain from absolute STATIC_URL (CDN configuration).
+
+        Purpose: Verify that _get_url() converts an absolute STATIC_URL
+            (with scheme and domain) to a relative path, ensuring correct
+            behavior on multi-site / CDN deployments where STATIC_URL is
+            set to a full URL like https://cdn.example.com/static/.
+        Category: Normal case
+        Target: LocalFileStorage._get_url(path)
+        Technique: Equivalence partitioning
+        Test data: STATIC_URL with https scheme and CDN domain
+        """
+        backend = LocalFileStorage()
+
+        with mock.patch(
+            "wagtail_asset_publisher.storage.local.settings"
+        ) as mock_settings:
+            mock_settings.STATIC_URL = "https://cdn.example.com/static/"
+
+            result = backend._get_url("page-assets/css/42.css")
+
+        assert result == "/static/page-assets/css/42.css"
+
+    def test_get_url_preserves_relative_static_url(self):
+        """Preserve relative STATIC_URL unchanged.
+
+        Purpose: Verify that _get_url() returns the URL unchanged when
+            STATIC_URL is already a relative path, ensuring no unintended
+            transformation on standard local development setups.
+        Category: Normal case
+        Target: LocalFileStorage._get_url(path)
+        Technique: Equivalence partitioning
+        Test data: STATIC_URL with relative path (/static/)
+        """
+        backend = LocalFileStorage()
+
+        with mock.patch(
+            "wagtail_asset_publisher.storage.local.settings"
+        ) as mock_settings:
+            mock_settings.STATIC_URL = "/static/"
 
             result = backend._get_url("page-assets/css/42.css")
 


### PR DESCRIPTION
## Summary
- Strip domain from absolute URLs returned by storage backends so that multi-site deployments serve assets from the correct domain
- Both `DjangoStorageBackend.save()` and `LocalFileStorage._get_url()` now return path-only URLs when the underlying storage returns absolute URLs

Closes #59

## Changes
| File | Change |
|------|--------|
| `storage/django_storage.py` | Strip domain from `default_storage.url()` return value using `urlparse` |
| `storage/local.py` | Strip domain from `STATIC_URL`-based URL using `urlparse` |
| `tests/test_storage.py` | Add 4 tests for absolute URL stripping and relative URL preservation |

## Test plan
- [x] All 373 existing tests pass
- [x] New tests verify absolute URL → path-only conversion
- [x] New tests verify relative URLs are preserved unchanged